### PR TITLE
Fixed Tazer mutator allowing selection of others.

### DIFF
--- a/GoonBase/mutators/mutator_all_tazers.lua
+++ b/GoonBase/mutators/mutator_all_tazers.lua
@@ -4,7 +4,7 @@
 ----------
 
 local Mutator = class(BaseMutator)
-Mutator.Id = "AllTaserSpawns"
+Mutator.Id = "AllTazerSpawns"
 Mutator.OptionsName = "Danger, Danger! High Voltage!"
 Mutator.OptionsDesc = "Replace all spawning units with Tasers"
 Mutator.Incompatibilities = { "AllCloakerSpawns", "AllBulldozerSpawns", "AllShieldSpawns" }


### PR DESCRIPTION
This fixes the issue where selecting the tazer mutator would allow you to select a second enemy mutator due to a typo.
