### PR TITLE
Fix push to interact configs being forced to default

### DIFF
--- a/GoonMod/mods/push_to_interact.lua
+++ b/GoonMod/mods/push_to_interact.lua
@@ -33,13 +33,13 @@ GoonBase.Options.PushToInteract.Enabled 			= GoonBase.Options.PushToInteract.Ena
 GoonBase.Options.PushToInteract.InteractionMinTime 	= GoonBase.Options.PushToInteract.InteractionMinTime or 2
 GoonBase.Options.PushToInteract.HoldAllEnabled 		= GoonBase.Options.PushToInteract.HoldAllEnabled
 GoonBase.Options.PushToInteract.UseStopKey 			= GoonBase.Options.PushToInteract.UseStopKey
-if not GoonBase.Options.PushToInteract.Enabled then
+if GoonBase.Options.PushToInteract.Enabled == nil then
 	GoonBase.Options.PushToInteract.Enabled = true
 end
-if not GoonBase.Options.PushToInteract.HoldAllEnabled then
+if GoonBase.Options.PushToInteract.HoldAllEnabled nil then
 	GoonBase.Options.PushToInteract.HoldAllEnabled = false
 end
-if not GoonBase.Options.PushToInteract.UseStopKey then
+if GoonBase.Options.PushToInteract.UseStopKey == nil then
 	GoonBase.Options.PushToInteract.UseStopKey = false
 end
 
@@ -78,7 +78,7 @@ Hooks:Add("MenuManagerInitialize", "MenuManagerInitialize_" .. Mod:ID(), functio
 end)
 
 -- Hooks
-Hooks:Add("PlayerStandardCheckActionInteract", "PlayerStandardCheckActionInteract_PushToInteract", function(ply, t, input)		
+Hooks:Add("PlayerStandardCheckActionInteract", "PlayerStandardCheckActionInteract_PushToInteract", function(ply, t, input)
 
 	if not PushToInteract:IsEnabled() then
 		return nil
@@ -107,19 +107,19 @@ Hooks:Add("PlayerStandardCheckActionInteract", "PlayerStandardCheckActionInterac
 end)
 
 function PushToInteract:IsEnabled()
-	return GoonBase.Options.PushToInteract.Enabled or true
+	return GoonBase.Options.PushToInteract.Enabled
 end
 
 function PushToInteract:ShouldHoldAllInteractions()
-	return GoonBase.Options.PushToInteract.HoldAllEnabled or false
+	return GoonBase.Options.PushToInteract.HoldAllEnabled
 end
 
 function PushToInteract:MinimumInteractionTime()
-	return GoonBase.Options.PushToInteract.InteractionMinTime or 2
+	return GoonBase.Options.PushToInteract.InteractionMinTime
 end
 
 function PushToInteract:ShouldUseStopKey()
-	return GoonBase.Options.PushToInteract.UseStopKey or false
+	return GoonBase.Options.PushToInteract.UseStopKey
 end
 
 function PushToInteract:ShouldHoldInteraction( interaction_data )


### PR DESCRIPTION
Currently Push to interact cannot be disabled, as well as any setting set to "false" will be forced to its default setting

Due to dealing with true/false  the checks need to be against nil for setting the initial default setting. However the problem persists when you call IsEnabled() and in theory any of the others, because if you set enabled to false, the or will trigger which in turn returns true causing it to still work.

None of the calls need to return an or value. Due to setting the defaults if they do not exist (for example no saved config) these functions will always have a setting